### PR TITLE
Fix error in using 'Gtags -f'

### DIFF
--- a/autoload/gtags.vim
+++ b/autoload/gtags.vim
@@ -286,7 +286,10 @@ function! s:ExecLoad(option, long_option, pattern) abort
         let l:cmd = g:gtags_global_command . ' ' . l:option . 'e ' . g:Gtags_Shell_Quote_Char . a:pattern . g:Gtags_Shell_Quote_Char
     endif
 
-    exe 'lcd ' . s:FILE.unify_path(g:gtags_cache_dir) . s:FILE.path_to_fname(getcwd())
+    let l:root = SpaceVim#plugins#projectmanager#current_root()
+    let $GTAGSROOT = l:root
+    let $GTAGSDBPATH = s:FILE.unify_path(g:gtags_cache_dir) . s:FILE.path_to_fname(l:root)
+    exe 'lcd ' . l:root
     let l:result = system(l:cmd)
     e
     if v:shell_error != 0


### PR DESCRIPTION
As shown in the official GNU global site, while referring a DB outside project source tree, we have to set up the environment variable GTAGSROOT and GTAGSDBPATH. And we should be in the root of the project.
```
    $ mkdir /var/dbpath
    $ cd /cdrom/src                 # the root of source tree
    $ gtags /var/dbpath             # make tag files in /var/dbpath
    $ export GTAGSROOT=`pwd`
    $ export GTAGSDBPATH=/var/dbpath
    $ global func
```