### PR TITLE
Fix linux kernel tags generate error

### DIFF
--- a/autoload/gtags.vim
+++ b/autoload/gtags.vim
@@ -484,7 +484,7 @@ function! gtags#update(bang) abort
     if a:bang && filereadable('GTAGS')
         let cmd = ['gtags', '--single-update', expand('%:p')]
     else
-        let cmd = ['gtags']
+        let cmd = ['gtags', '--skip-unreadable']
     endif
     let dir = s:FILE.unify_path(g:gtags_cache_dir) . dir
     if !isdirectory(dir)


### PR DESCRIPTION
When run GtagsGenerate cmd in kernel source tree it exit with error.
There is a soft link file to system file that own to root user.
Ignore unreadable file to gtags.
See SpaceVim issue #2375