### PR TITLE
Fix gtags issue while switch between projects

### DIFF
--- a/autoload/gtags.vim
+++ b/autoload/gtags.vim
@@ -245,15 +245,30 @@ function! s:ExecLoad(option, long_option, pattern) abort
         let l:cmd = g:gtags_global_command . ' ' . l:option . 'e ' . g:Gtags_Shell_Quote_Char . a:pattern . g:Gtags_Shell_Quote_Char
     endif
 
+    let l:restore_gtagsroot = 0
     if empty($GTAGSROOT)
       let $GTAGSROOT = getcwd()
+      let l:restore_gtagsroot = 1
     endif
 
+    let l:restore_gtagsdbpath = 0
     if empty($GTAGSDBPATH)
       let $GTAGSDBPATH = s:FILE.unify_path(g:gtags_cache_dir) . s:FILE.path_to_fname(SpaceVim#plugins#projectmanager#current_root())
+      let l:restore_gtagsdbpath = 1
     endif
 
     let l:result = system(l:cmd)
+
+    " restore $GTAGSROOT and $GTAGSDBPATH to make it possible to switch
+    " between multiple projects or parent/child projects
+    if l:restore_gtagsroot
+      let $GTAGSROOT = ''
+    endif
+
+    if l:restore_gtagsdbpath
+      let $GTAGSDBPATH = ''
+    endif
+
     e
     if v:shell_error != 0
         if v:shell_error == 2

--- a/autoload/gtags.vim
+++ b/autoload/gtags.vim
@@ -247,7 +247,7 @@ function! s:ExecLoad(option, long_option, pattern) abort
 
     let l:restore_gtagsroot = 0
     if empty($GTAGSROOT)
-      let $GTAGSROOT = getcwd()
+      let $GTAGSROOT = SpaceVim#plugins#projectmanager#current_root()
       let l:restore_gtagsroot = 1
     endif
 


### PR DESCRIPTION
If we switch between multiple projects, e.g. a parent project and child project:

```
.git/
parent.cpp
sub/.git
sub/sub.h
sub/sub.cpp
```

There're two issues:

1. In the first project that using gtags, the ``$GTAGSROOT`` and ``$GTAGSDBPATH`` is set.  When we switch to another project, those environments wouldn't be changed to the values of the second project.

2. ``$GTAGSROOT`` is set to ``getcwd()``, while ``$GTAGSDBPATH`` is set to ``current_root()``. If we change cwd before calling gtags, it opens the wrong path

This PR fix the above issues.