### PR TITLE
Fix mismatched GTAGSROOT and GTAGSDBPATH.

### DIFF
--- a/autoload/gtags.vim
+++ b/autoload/gtags.vim
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+
 if !executable('gtags')
     echohl WarningMsg
     echom 'you need to install gnu global!'

--- a/autoload/gtags.vim
+++ b/autoload/gtags.vim
@@ -253,7 +253,7 @@ function! s:ExecLoad(option, long_option, pattern) abort
 
     let l:restore_gtagsdbpath = 0
     if empty($GTAGSDBPATH)
-      let $GTAGSDBPATH = s:FILE.unify_path(g:gtags_cache_dir) . s:FILE.path_to_fname(SpaceVim#plugins#projectmanager#current_root())
+      let $GTAGSDBPATH = s:FILE.unify_path(g:gtags_cache_dir) . s:FILE.path_to_fname($GTAGSROOT)
       let l:restore_gtagsdbpath = 1
     endif
 

--- a/autoload/gtags/logger.vim
+++ b/autoload/gtags/logger.vim
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+
 let s:LOG = SpaceVim#api#import('logger')
 
 call s:LOG.set_name('Gtags')

--- a/plugin/gtags.vim
+++ b/plugin/gtags.vim
@@ -3,6 +3,7 @@
 " The gtags.vim plug-in script integrates the GNU GLOBAL source code tag
 " system with Vim. About the details, see http://www.gnu.org/software/global/.
 
+scriptencoding utf-8
 
 let g:gtags_cache_dir = '~/.cache/SpaceVim/tags/'
 


### PR DESCRIPTION
If GTAGSROOT is set while GTAGSDBPATH is unset, the later may be set to
a path difference from GTAGSROOT.  This commit make sure that
GTAGSDBPATH is based on GTAGSROOT.